### PR TITLE
Fix build with vte 0.30

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ INCLUDE_DIRECTORIES(${TERMIT_SOURCE_DIR})
 INCLUDE (FindGTK)
 
 INCLUDE (FindPkgConfig)
-pkg_search_module(VTE REQUIRED libvte-2.90>=0.20 vte-2.90>=0.20)
+pkg_search_module(VTE REQUIRED vte-2.90>=0.20)
 IF(NOT VTE_FOUND)
   message(FATAL_ERROR "vte library not found")
 ENDIF(NOT VTE_FOUND)


### PR DESCRIPTION
pkgconfig file for gtk3 version of vte is renamed to vte-2.90.pc
