### PR TITLE
Set project language to C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU General Public License
 # along with termit. If not, see <http://www.gnu.org/licenses/>.
 
-PROJECT(TERMIT)
+PROJECT(TERMIT C)
 
 cmake_minimum_required(VERSION 2.6.1 FATAL_ERROR)
 SET(CMAKE_VERSION "${CMAKE_CACHE_MAJOR_VERSION}.${CMAKE_CACHE_MINOR_VERSION}.${CMAKE_CACHE_RELEASE_VERSION}")


### PR DESCRIPTION
According to http://www.cmake.org/cmake/help/cmake-2-8-docs.html#command:project
cmake by default set project languages for C and C++, but termit is only
in C.

This change instruct cmake to not look for C++ compiler and allow
build if this compiler is missing.

Patch taken from http://cvs.pld-linux.org/cgi-bin/cvsweb.cgi/packages/termit/termit-language.patch
