### PR TITLE
api: add lastTabIndex() which return the index of the last tab

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -61,6 +61,8 @@ _func_ - function to be called.
 _func_ - function to be called.
 
 
+*lastTabIndex()* - Returns the index of the last tab -- same as the number of tabs.
+
 *loadSessionDlg()* - Displays "Load session" dialog.
 
 

--- a/doc/termit.1
+++ b/doc/termit.1
@@ -172,6 +172,9 @@ data
 ) - For each visible terminal row executes function passing row as argument.
     func - function to be called.
 .P
+.B lastTabIndex
+() - Returns the index of the last tab -- same as the number of tabs.
+.P
 .B loadSessionDlg
 () - Displays "Load session" dialog.
 .P

--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -435,6 +435,12 @@ static int termit_lua_currentTabIndex(lua_State* ls)
     return 1;
 }
 
+static int termit_lua_lastTabIndex(lua_State* ls)
+{
+    lua_pushinteger(ls, termit_get_last_tab_index());
+    return 1;
+}
+
 static int termit_lua_loadSessionDialog(lua_State* ls)
 {
     termit_on_load_session();
@@ -675,6 +681,7 @@ struct TermitLuaFunction
     {"forEachRow", termit_lua_forEachRow, 0},
     {"forEachVisibleRow", termit_lua_forEachVisibleRow, 0},
     {"loadSessionDlg", termit_lua_loadSessionDialog, 0},
+    {"lastTabIndex", termit_lua_lastTabIndex, 0},
     {"nextTab", termit_lua_nextTab, 0},
     {"openTab", termit_lua_openTab, 0},
     {"paste", termit_lua_paste, 0},

--- a/src/termit_core_api.c
+++ b/src/termit_core_api.c
@@ -684,6 +684,11 @@ int termit_get_current_tab_index()
     return gtk_notebook_get_current_page(GTK_NOTEBOOK(termit.notebook));
 }
 
+int termit_get_last_tab_index()
+{
+    return gtk_notebook_get_n_pages(GTK_NOTEBOOK(termit.notebook));
+}
+
 void termit_set_kb_policy(enum TermitKbPolicy kbp)
 {
     configs.kb_policy = kbp;

--- a/src/termit_core_api.h
+++ b/src/termit_core_api.h
@@ -61,6 +61,7 @@ void termit_tab_set_audible_bell(struct TermitTab* pTab, gboolean audible_bell);
 void termit_tab_set_visible_bell(struct TermitTab* pTab, gboolean visible_bell);
 
 int termit_get_current_tab_index();
+int termit_get_last_tab_index();
 gchar* termit_get_pid_dir(pid_t pid);
 
 /**


### PR DESCRIPTION
Index of the last tab is also the same as the total number of tabs.

Signed-off-by: Anurag Priyam anurag08priyam@gmail.com

---

An intended use case is to be able to display index of the focused tab out of total in the window title, like:

```
[1/6]: /home/yeban/src/termit
```
