### PR TITLE
currentTabIndex: offset the index returned by termit_get_current_tab_ind...

### DIFF
--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -431,7 +431,7 @@ static int termit_lua_currentTab(lua_State* ls)
 
 static int termit_lua_currentTabIndex(lua_State* ls)
 {
-    lua_pushinteger(ls, termit_get_current_tab_index());
+    lua_pushinteger(ls, termit_get_current_tab_index() + 1);
     return 1;
 }
 


### PR DESCRIPTION
...ex by 1

Account for the different indexing convention in C (starts with 0), and Lua (
starts with 1).

Signed-off-by: Anurag Priyam anurag08priyam@gmail.com
