### PR TITLE
fix wrong section in manpage: 30->1

### DIFF
--- a/doc/termit.1
+++ b/doc/termit.1
@@ -1,7 +1,7 @@
 .\" Process this file with
 .\" groff -man -Tascii foo.1
 .\"
-.TH TERMIT 30 "NOV 2008" Linux "User Manuals"
+.TH TERMIT 1 "NOV 2008" Linux "User Manuals"
 .SH NAME
 termit \- lightweight terminal emulator
 .SH SYNOPSIS


### PR DESCRIPTION
from man 7 groff_man: [1]

.TH title section [extra1] [extra2] [extra3]
              Set the title of the man page to title and the section  to  sec-
              tion,  which  must  take  on a value between 1 and 8.

[1] http://manpages.debian.net/cgi-bin/man.cgi?query=groff_man&sektion=7
