### PR TITLE
remove obsolete encoding key from desktop entry

### DIFF
--- a/doc/termit.desktop
+++ b/doc/termit.desktop
@@ -6,7 +6,6 @@ Exec=termit
 Categories=Utility;TerminalEmulator;GTK
 Comment=Lightweight terminal emulator
 Comment[ru]=Эмулятор терминала
-Encoding=UTF-8
 GenericName=Terminal emulator
 GenericName[ru]=Эмулятор терминала
 Terminal=false


### PR DESCRIPTION
from: http://lintian.debian.org/tags/desktop-entry-contains-encoding-key.html

The Encoding key is now deprecated by the FreeDesktop standard and all strings are required to be encoded in UTF-8. This desktop entry explicitly specifies an Encoding of UTF-8, which is harmless but no longer necessary.

The desktop-file-validate tool in the desktop-file-utils package is useful for checking the syntax of desktop entries.

Refer to http://standards.freedesktop.org/desktop-entry-spec/1.0/apc.html for details.
