### PR TITLE
fix hyphen-used-as-minus-sign in manpage

### DIFF
--- a/doc/termit.1
+++ b/doc/termit.1
@@ -3,74 +3,74 @@
 .\"
 .TH TERMIT 30 "NOV 2008" Linux "User Manuals"
 .SH NAME
-termit \- lightweight terminal emulator
+termit \(hy lightweight terminal emulator
 .SH SYNOPSIS
-.B termit [-option ...]
+.B termit [\-option ...]
 .SH DESCRIPTION
 .B termit
-is a vte-based lightweight terminal emulator. All configuration
-is done via Lua-scripts. The only other dependencies are 
+is a vte\(hybased lightweight terminal emulator. All configuration
+is done via Lua\(hyscripts. The only other dependencies are 
 Gtk+ and Vte.
 .SH OPTIONS
-.BR -h
+.BR \-h
 or
-.BR --help
+.BR \-\-help
 .RS
 Print help
 .RE
-.BR -v
+.BR \-v
 or
-.BR --version
+.BR \-\-version
 .RS
 Print version number
 .RE
-.BR -e
+.BR \-e
 or
-.BR --execute
+.BR \-\-execute
 .I cmd
 .RS
 Use
 .I cmd
 as shell
 .RE
-.BR -i
+.BR \-i
 or
-.BR --init
+.BR \-\-init
 .I file
 .RS
 Use
 .I file
 instead of default rc.lua
 .RE
-.BR -n
+.BR \-n
 or
-.BR --name
+.BR \-\-name
 .I name
 .RS
 Use
 .I name
 in window name hint
 .RE
-.BR -c
+.BR \-c
 or
-.BR --class
+.BR \-\-class
 .I class
 .RS
 Use
 .I class
 in window class hint
 .RE
-.BR -r
+.BR \-r
 or
-.BR --role
+.BR \-\-role
 .I role
 .RS
 Use
 .I role
-in window role Gtk-hint
+in window role Gtk\(hyhint
 .RE
 .P
-termit --execute=zsh --init=session.lua --name=TermitName --class=TermitClass --role=TermitRole
+termit \-\-execute=zsh \-\-init=session.lua \-\-name=TermitName \-\-class=TermitClass \-\-role=TermitRole
 .P
 .RE
 .SH FILES
@@ -89,271 +89,271 @@ Example rc.lua file. Demonstrates usage of almost all available settings.
 .B activateTab
 (
 .I tab_index
-) - Activates tab by index.
-    tab_index - index of tab to activate. Index of the first tab is 1.
+) \(hy Activates tab by index.
+    tab_index \(hy index of tab to activate. Index of the first tab is 1.
 .P
 .B addMenu
 (
 .I menu
-) - Adds menu in menubar.
-    menu - table of TermitMenuItem type.
+) \(hy Adds menu in menubar.
+    menu \(hy table of TermitMenuItem type.
 .P
 .B addPopupMenu
 (
 .I menu
 )
 Adds menu in popup menu, similar to addMenu.
-    menu - table of TermitMenuItem type.
+    menu \(hy table of TermitMenuItem type.
 .P
 .B bindKey
 (
 .I keys
 ,
 .I luaFunction
-) - Sets new keybinding. If luaFunction is 
+) \(hy Sets new keybinding. If luaFunction is 
 .I nil
 removes keybinding.
-    keys - string with keybinding. Available modifiers are Alt Ctrl Shift Meta Super Hyper.
-    luaFunction - callback function
+    keys \(hy string with keybinding. Available modifiers are Alt Ctrl Shift Meta Super Hyper.
+    luaFunction \(hy callback function
 .P
 .B bindMouse
 (
 .I event
 ,
 .I luaFunction
-) - Sets new mouse-binding. If luaFunction is 
+) \(hy Sets new mouse\(hybinding. If luaFunction is 
 .I nil
-removes mouse-binding.
-    event - string with one of those values: DoubleClick
-    luaFunction - callback function
+removes mouse\(hybinding.
+    event \(hy string with one of those values: DoubleClick
+    luaFunction \(hy callback function
 .P
 .B closeTab
-() - Closes active tab.
+() \(hy Closes active tab.
 .P
 .B copy
-() - Copies selection into tab's buffer.
+() \(hy Copies selection into tab's buffer.
 .P
 .B currentTab
-() - Returns current tab of TermitTabInfo.
+() \(hy Returns current tab of TermitTabInfo.
 .P
 .B currentTabIndex
-() - Returns current tab index.
+() \(hy Returns current tab index.
 .P
 .B feed
 (
 .I
 data
-) - Interprets data as if it were data received from a terminal process.
+) \(hy Interprets data as if it were data received from a terminal process.
 .P
 .B feedChild
 (
 .I
 data
-) - Sends a data to the terminal as if it were data entered by the user at the keyboard.
+) \(hy Sends a data to the terminal as if it were data entered by the user at the keyboard.
 .P
 .B findDlg
-() - Opens search entry. (Enabled when build with vte version >= 0.26)
+() \(hy Opens search entry. (Enabled when build with vte version >= 0.26)
 .P
 .B findNext
-() - Searches the next string matching search regex. (Enabled when build with vte version >= 0.26)
+() \(hy Searches the next string matching search regex. (Enabled when build with vte version >= 0.26)
 .P
 .B findPrev
-() - Searches the previous string matching search regex. (Enabled when build with vte version >= 0.26)
+() \(hy Searches the previous string matching search regex. (Enabled when build with vte version >= 0.26)
 .P
 .B forEachRow
 (
 .I func
-) - For each terminal row in entire scrollback buffer executes function passing row as argument.
-    func - function to be called.
+) \(hy For each terminal row in entire scrollback buffer executes function passing row as argument.
+    func \(hy function to be called.
 .P
 .B forEachVisibleRow
 (
 .I func
-) - For each visible terminal row executes function passing row as argument.
-    func - function to be called.
+) \(hy For each visible terminal row executes function passing row as argument.
+    func \(hy function to be called.
 .P
 .B loadSessionDlg
-() - Displays "Load session" dialog.
+() \(hy Displays "Load session" dialog.
 .P
 .B nextTab
-() - Activates next tab.
+() \(hy Activates next tab.
 .P
 .B openTab
 (
 .I tabInfo
-) - Opens new tab.
-    tabinfo - table of TermitTabInfo with tab settings.
+) \(hy Opens new tab.
+    tabinfo \(hy table of TermitTabInfo with tab settings.
 .P
 .B paste
-() - Pastes tab's buffer.
+() \(hy Pastes tab's buffer.
 .P
 .B preferencesDlg
-() - Displays "Preferences" dialog.
+() \(hy Displays "Preferences" dialog.
 .P
 .B prevTab
-() - Activates previous tab.
+() \(hy Activates previous tab.
 .P
 .B quit
-() - Quit.
+() \(hy Quit.
 .P
 .B reconfigure
-() - Sets all configurable variables to defaults and forces rereading rc.lua.
+() \(hy Sets all configurable variables to defaults and forces rereading rc.lua.
 .P
 .B saveSessionDlg
-() - Displays "Save session" dialog.
+() \(hy Displays "Save session" dialog.
 .P
 .B selection
-() - Returns selected text from current tab.
+() \(hy Returns selected text from current tab.
 .P
 .B setColormap
 (
 .I colormap
-) - Changes colormap for active tab.
-    colormap - array with 8 or 16 or 24 colors.
+) \(hy Changes colormap for active tab.
+    colormap \(hy array with 8 or 16 or 24 colors.
 .P
 .B setEncoding
 (
 .I encoding
-) - Changes encoding for active tab.
-    encoding - string with encoding name.
+) \(hy Changes encoding for active tab.
+    encoding \(hy string with encoding name.
 .P
 .B setKbPolicy
 (
 .I kb_policy
-) - Sets keyuboard policy for shortcuts.
-    kb_policy - string with one of those values:
-        keycode - use hardware keyboard codes (XkbLayout-independent)
-        keysym - use keysym values (XkbLayout-dependent)
+) \(hy Sets keyuboard policy for shortcuts.
+    kb_policy \(hy string with one of those values:
+        keycode \(hy use hardware keyboard codes (XkbLayout\(hyindependent)
+        keysym \(hy use keysym values (XkbLayout\(hydependent)
 .P
 .B setOptions
 (
 .I opts
-) - Changes default options.
-    opts - TermitOptions table with new options.
+) \(hy Changes default options.
+    opts \(hy TermitOptions table with new options.
 .P
 .B setTabBackgroundColor
 (
 .I color
-) - Changes background color for active tab.
-    color - string with new color.
+) \(hy Changes background color for active tab.
+    color \(hy string with new color.
 .P
 .B setTabFont
 (
 .I font
-) - Changes font for active tab.
-    font - string with new font.
+) \(hy Changes font for active tab.
+    font \(hy string with new font.
 .P
 .B setTabForegroundColor
 (
 .I color
-) - Changes foreground (e.g. font) color for active tab.
-    color - string with new color.
+) \(hy Changes foreground (e.g. font) color for active tab.
+    color \(hy string with new color.
 .P
 .B setTabTitle
 (
 .I tabTitle
-) - Changes title for active tab.
-    tabTitle - string with new tab title.
+) \(hy Changes title for active tab.
+    tabTitle \(hy string with new tab title.
 .P
 .B setTabTitleDlg
-() - Displays "Set tab title" dialog.
+() \(hy Displays "Set tab title" dialog.
 .P
 .B setWindowTitle
 (
 .I title
-) - Changes termit window title.
-    title - string with new title.
+) \(hy Changes termit window title.
+    title \(hy string with new title.
 .P
 .B spawn
 (
 .I command
-) - Spawns command (works via shell).
-    command - string with command and arguments.
+) \(hy Spawns command (works via shell).
+    command \(hy string with command and arguments.
 .P
 .B toggleMenubar
-() - Displays or hides menubar.
+() \(hy Displays or hides menubar.
 .P
 .P
 .B toggleTabbar
-() - Displays or hides tabbar.
+() \(hy Displays or hides tabbar.
 .P
 
 .B "Types:"
 
 .B TermitEraseBinding
-- one of those string values:
-    Auto - VTE_ERASE_AUTO
-    AsciiBksp - VTE_ERASE_ASCII_BACKSPACE
-    AsciiDel - VTE_ERASE_ASCII_DELETE
-    EraseDel - VTE_ERASE_DELETE_SEQUENCE
-    EraseTty - VTE_ERASE_TTY
+\(hy one of those string values:
+    Auto \(hy VTE_ERASE_AUTO
+    AsciiBksp \(hy VTE_ERASE_ASCII_BACKSPACE
+    AsciiDel \(hy VTE_ERASE_ASCII_DELETE
+    EraseDel \(hy VTE_ERASE_DELETE_SEQUENCE
+    EraseTty \(hy VTE_ERASE_TTY
 .P
 For detailed description look into Vte docs.
 .P
 .B TermitKeybindings
-- table with predefined keybindings.
-    closeTab - 'Ctrl-w'
-    copy - 'Ctrl-Insert'
-    nextTab - 'Alt-Right'
-    openTab - 'Ctrl-t'
-    paste - 'Shift-Insert'
-    prevTab - 'Alt-Left'
+\(hy table with predefined keybindings.
+    closeTab \(hy 'Ctrl\(hyw'
+    copy \(hy 'Ctrl\(hyInsert'
+    nextTab \(hy 'Alt\(hyRight'
+    openTab \(hy 'Ctrl\(hyt'
+    paste \(hy 'Shift\(hyInsert'
+    prevTab \(hy 'Alt\(hyLeft'
 .P
 .B TermitMatch
-- table for matches.
-    field name - match regular expression
-    field value - lua callback for action on Left-click.
+\(hy table for matches.
+    field name \(hy match regular expression
+    field value \(hy lua callback for action on Left\(hyclick.
 .P
 .B TermitMenuItem
-- table for menuitems.
-    accel - accelerator for menuitem. String with keybinding
-    action - lua-function to execute when item activated
-    name - name for menuitem
+\(hy table for menuitems.
+    accel \(hy accelerator for menuitem. String with keybinding
+    action \(hy lua\(hyfunction to execute when item activated
+    name \(hy name for menuitem
 .P
 .B TermitOptions
-- table with termit options.
-    allowChangingTitle - auto change title (similar to xterm)
-    audibleBell - enables audible bell
-    backgroundColor - background color
-    backspaceBinding - reaction on backspace key (one of TermitEraseBinding)
-    colormap - array with 8 or 16 or 24 colors
-    deleteBinding - reaction on delete key (one of TermitEraseBinding)
-    encoding - default encoding
-    fillTabbar - expand tabs' titles to fill whole tabbar
-    font - font name
-    foregroundColor - foreground color
-    geometry - cols x rows to start with
-    getTabTitle - lua function to generate new tab title
-    getWindowTitle - lua function to generate new window title
-    hideMenubar - hide menubar
-    hideTabbar - hide tabbar
-    hideSingleTab - hide menubar when only 1 tab present
-    imageFile - path to image to be set on the background
-    matches - table with items of TermitMatch type
-    scrollbackLines - the length of scrollback buffer
-    setStatusbar - lua function to generate new statusbar message
-    showScrollbar - display scrollbar
-    tabName - default tab name
-    tabs - table with items of TermitTabInfo type
-    transparency - use transparency level [0,1]
-    visibleBell - enables visible bell
-    urgencyOnBell - set WM-hint 'urgent' on termit window when bell
-    wordChars - word characters (double click selects word)
+\(hy table with termit options.
+    allowChangingTitle \(hy auto change title (similar to xterm)
+    audibleBell \(hy enables audible bell
+    backgroundColor \(hy background color
+    backspaceBinding \(hy reaction on backspace key (one of TermitEraseBinding)
+    colormap \(hy array with 8 or 16 or 24 colors
+    deleteBinding \(hy reaction on delete key (one of TermitEraseBinding)
+    encoding \(hy default encoding
+    fillTabbar \(hy expand tabs' titles to fill whole tabbar
+    font \(hy font name
+    foregroundColor \(hy foreground color
+    geometry \(hy cols x rows to start with
+    getTabTitle \(hy lua function to generate new tab title
+    getWindowTitle \(hy lua function to generate new window title
+    hideMenubar \(hy hide menubar
+    hideTabbar \(hy hide tabbar
+    hideSingleTab \(hy hide menubar when only 1 tab present
+    imageFile \(hy path to image to be set on the background
+    matches \(hy table with items of TermitMatch type
+    scrollbackLines \(hy the length of scrollback buffer
+    setStatusbar \(hy lua function to generate new statusbar message
+    showScrollbar \(hy display scrollbar
+    tabName \(hy default tab name
+    tabs \(hy table with items of TermitTabInfo type
+    transparency \(hy use transparency level [0,1]
+    visibleBell \(hy enables visible bell
+    urgencyOnBell \(hy set WM\(hyhint 'urgent' on termit window when bell
+    wordChars \(hy word characters (double click selects word)
 .P
 .B TermitTabInfo
-- table with tab settings:
+\(hy table with tab settings:
     command
     encoding
-    font - font string
-    fontSize - font size
-    pid - process id
+    font \(hy font string
+    fontSize \(hy font size
+    pid \(hy process id
     title
     workingDir
 .P
 .B "Globals:"
 
 .B tabs
-- table with tab settings, access specific tabs by index.
+\(hy table with tab settings, access specific tabs by index.
 .RS
 .SH EXAMPLES
 Look inside provided rc.lua.example.


### PR DESCRIPTION
from
http://lintian.debian.org/tags/hyphen-used-as-minus-sign.html

This manual page seems to contain a hyphen where a minus sign was intended. By default, "-" chars are interpreted as hyphens (U+2010) by groff, not as minus signs (U+002D). Since options to programs use minus signs (U+002D), this means for example in UTF-8 locales that you cannot cut and paste options, nor search for them easily. The Debian groff package currently forces "-" to be interpreted as a minus sign due to the number of manual pages with this problem, but this is a Debian-specific modification and hopefully eventually can be removed.

"-" must be escaped ("-") to be interpreted as minus. If you really intend a hyphen (normally you don't), write it as "(hy" to emphasise that fact. See groff(7) and especially groff_char(7) for details, and also the thread starting with http://lists.debian.org/debian-devel/2003/debian-devel-200303/msg01481.html

If you use some tool that converts your documentation to groff format, this tag may indicate a bug in the tool. Some tools convert dashes of any kind to hyphens. The safe way of converting dashes is to convert them to "-".

Because this error can occur very often, Lintian shows only the first 10 occurrences for each man page and give the number of suppressed occurrences. If you want to see all warnings, run Lintian with the -d/--debug option.

Refer to /usr/share/doc/groff-base/README.Debian and the groff_char(7) manual page for details.
