### PR TITLE
make notebook borders configurable

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -206,6 +206,7 @@ pre. Example: enable Gnome-like tab switching
 * getWindowTitle - lua function to generate new window title
 * hideMenubar - hide menubar
 * hideTabbar - hide tabbar
+* showBorder - show notebook border
 * hideSingleTab - hide menubar when only 1 tab present
 * imageFile - path to image to be set on the background
 * matches - table with items of TermitMatch type

--- a/doc/rc.lua.example
+++ b/doc/rc.lua.example
@@ -14,6 +14,7 @@ defaults.transparency = 0.7
 --defaults.imageFile = '/tmp/img.png'
 defaults.hideSingleTab = false
 defaults.hideTabbar = false
+defaults.showBorder = true
 defaults.hideMenubar = false
 defaults.fillTabbar = true
 defaults.scrollbackLines = 4096

--- a/doc/termit.1
+++ b/doc/termit.1
@@ -369,6 +369,7 @@ For detailed description look into Vte docs.
     scrollbackLines     the length of scrollback buffer
     setStatusbar        lua function to generate new statusbar message
     showScrollbar       display scrollbar
+    showBorder          show notebook borders
     tabName             default tab name
     tabPos              tabbar position (Top, Bottom, Left, Right)
     tabs                table with items of TermitTabInfo type

--- a/src/configs.c
+++ b/src/configs.c
@@ -61,6 +61,7 @@ void termit_config_trace()
     TRACE("     hide_menubar            = %d", configs.hide_menubar);
     TRACE("     hide_tabbar             = %d", configs.hide_tabbar);
     TRACE("     fill_tabbar             = %d", configs.fill_tabbar);
+    TRACE("     show_border             = %d", configs.show_border);
     TRACE("     hide_single_tab         = %d", configs.hide_single_tab);
     TRACE("     scrollback_lines        = %d", configs.scrollback_lines);
     TRACE("     cols x rows             = %d x %d", configs.cols, configs.rows);
@@ -117,6 +118,7 @@ void termit_configs_set_defaults()
     configs.fill_tabbar = FALSE;
     configs.hide_menubar = FALSE;
     configs.hide_tabbar = FALSE;
+    configs.show_border = TRUE;
     configs.allow_changing_title = FALSE;
     configs.visible_bell = FALSE;
     configs.audible_bell = FALSE;

--- a/src/configs.h
+++ b/src/configs.h
@@ -43,6 +43,7 @@ struct Configs
     gboolean hide_menubar;
     gboolean hide_tabbar;
     gboolean fill_tabbar;
+    gboolean show_border;
     gboolean urgency_on_bell;
     gboolean allow_changing_title;
     gboolean audible_bell;

--- a/src/lua_conf.c
+++ b/src/lua_conf.c
@@ -241,6 +241,8 @@ void termit_lua_options_loader(const gchar* name, lua_State* ls, int index, void
         termit_config_get_boolean(&(p_cfg->hide_menubar), ls, index);
     else if (!strcmp(name, "hideTabbar"))
         termit_config_get_boolean(&(p_cfg->hide_tabbar), ls, index);
+    else if (!strcmp(name, "showBorder"))
+        termit_config_get_boolean(&(p_cfg->show_border), ls, index);
     else if (!strcmp(name, "scrollbackLines"))
         termit_config_getuint(&(p_cfg->scrollback_lines), ls, index);
     else if (!strcmp(name, "allowChangingTitle"))

--- a/src/termit.c
+++ b/src/termit.c
@@ -301,6 +301,7 @@ static void termit_init(const gchar* initFile, const gchar* command)
 
     if (!configs.allow_changing_title)
         termit_set_window_title(configs.default_window_title);
+    gtk_notebook_set_show_border(GTK_NOTEBOOK(termit.notebook), configs.show_border);
 }
 
 enum {


### PR DESCRIPTION
This adds a new config option 'showBorders', allowing to disable notebook borders if not desired. Default is TRUE, though.

This should close issue #63.
