### PR TITLE
add topMenu option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	Added topMenu option (by HildigerR Vergaray).
 	Removed any support for Gtk+3. Only Vte<0.29 and Gtk+2 are supported.
 version 2.10.1
 	Fixed error with conflicting libvte/Gtk versions

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -205,6 +205,7 @@ pre. Example: enable Gnome-like tab switching
 * getTabTitle - lua function to generate new tab title
 * getWindowTitle - lua function to generate new window title
 * hideMenubar - hide menubar
+* topMenu - place the menubar at the top of the window
 * hideTabbar - hide tabbar
 * showBorder - show notebook border
 * hideSingleTab - hide tabbar when only 1 tab present

--- a/doc/rc.lua.example
+++ b/doc/rc.lua.example
@@ -16,6 +16,7 @@ defaults.hideSingleTab = false
 defaults.hideTabbar = false
 defaults.showBorder = true
 defaults.hideMenubar = false
+defailts.topMenu = false
 defaults.fillTabbar = true
 defaults.scrollbackLines = 4096
 defaults.geometry = '80x24'

--- a/doc/termit.1
+++ b/doc/termit.1
@@ -380,6 +380,7 @@ For detailed description look into Vte docs.
     getTabTitle         lua function to generate new tab title
     getWindowTitle      lua function to generate new window title
     hideMenubar         hide menubar
+    topMenu             place menubar at the top of the window
     hideTabbar          hide tabbar
     hideSingleTab       hide tabbar when only 1 tab present
     imageFile           path to image to be set on the background

--- a/etc/termit/rc.lua
+++ b/etc/termit/rc.lua
@@ -9,6 +9,7 @@ defaults.geometry = '80x24'
 defaults.hideSingleTab = false
 defaults.showScrollbar = true
 defaults.fillTabbar = false
+defaults.topMenu = false
 defaults.hideMenubar = false
 defaults.allowChangingTitle = false
 defaults.visibleBell = false

--- a/src/configs.c
+++ b/src/configs.c
@@ -58,6 +58,7 @@ void termit_config_trace()
     TRACE("     default_encoding        = %s", configs.default_encoding);
     TRACE("     default_word_chars      = %s", configs.default_word_chars);
     TRACE("     show_scrollbar          = %d", configs.show_scrollbar);
+    TRACE("     top_menu                = %d", configs.top_menu);
     TRACE("     hide_menubar            = %d", configs.hide_menubar);
     TRACE("     hide_tabbar             = %d", configs.hide_tabbar);
     TRACE("     fill_tabbar             = %d", configs.fill_tabbar);
@@ -116,6 +117,7 @@ void termit_configs_set_defaults()
     configs.hide_single_tab = FALSE;
     configs.show_scrollbar = TRUE;
     configs.fill_tabbar = FALSE;
+    configs.top_menu = FALSE;
     configs.hide_menubar = FALSE;
     configs.hide_tabbar = FALSE;
     configs.show_border = TRUE;

--- a/src/configs.h
+++ b/src/configs.h
@@ -40,6 +40,7 @@ struct Configs
     GArray* matches;            // Match
     gboolean hide_single_tab;
     gboolean show_scrollbar;
+    gboolean top_menu;
     gboolean hide_menubar;
     gboolean hide_tabbar;
     gboolean fill_tabbar;

--- a/src/lua_conf.c
+++ b/src/lua_conf.c
@@ -237,6 +237,8 @@ void termit_lua_options_loader(const gchar* name, lua_State* ls, int index, void
         termit_config_get_boolean(&(p_cfg->fill_tabbar), ls, index);
     else if (!strcmp(name, "hideSingleTab"))
         termit_config_get_boolean(&(p_cfg->hide_single_tab), ls, index);
+    else if (!strcmp(name, "topMenu"))
+        termit_config_get_boolean(&(p_cfg->top_menu), ls, index);
     else if (!strcmp(name, "hideMenubar"))
         termit_config_get_boolean(&(p_cfg->hide_menubar), ls, index);
     else if (!strcmp(name, "hideTabbar"))

--- a/src/termit.c
+++ b/src/termit.c
@@ -70,12 +70,9 @@ static void create_search(struct TermitData* termit)
 
 static void pack_widgets()
 {
-    GtkWidget *vbox = gtk_vbox_new(FALSE, 0);
+    termit.vbox = gtk_vbox_new(FALSE, 0);
     termit.hbox = gtk_hbox_new(FALSE, 0);
-    if( !configs.top_menu )
-        gtk_box_pack_start(GTK_BOX(termit.hbox), termit.menu_bar, FALSE, 0, 0);
-    else
-        gtk_box_pack_start(GTK_BOX(vbox), termit.menu_bar, FALSE, 0, 0);
+    gtk_box_pack_start((configs.top_menu)?GTK_BOX(termit.vbox):GTK_BOX(termit.hbox), termit.menu_bar, FALSE, 0, 0);
 
     gtk_box_pack_start(GTK_BOX(termit.hbox), termit.b_toggle_search, FALSE, 0, 0);
     gtk_box_pack_start(GTK_BOX(termit.hbox), termit.search_entry, FALSE, 0, 0);
@@ -83,9 +80,9 @@ static void pack_widgets()
     gtk_box_pack_start(GTK_BOX(termit.hbox), termit.b_find_next, FALSE, 0, 0);
     gtk_box_pack_start(GTK_BOX(termit.hbox), termit.statusbar, TRUE, 1, 0);
 
-    gtk_box_pack_start(GTK_BOX(vbox), termit.notebook, TRUE, 1, 0);
-    gtk_box_pack_start(GTK_BOX(vbox), termit.hbox, FALSE, 1, 0);
-    gtk_container_add(GTK_CONTAINER(termit.main_window), vbox);
+    gtk_box_pack_start(GTK_BOX(termit.vbox), termit.notebook, TRUE, 1, 0);
+    gtk_box_pack_start(GTK_BOX(termit.vbox), termit.hbox, FALSE, 1, 0);
+    gtk_container_add(GTK_CONTAINER(termit.main_window), termit.vbox);
 
     if (!gtk_notebook_get_n_pages(GTK_NOTEBOOK(termit.notebook)))
         termit_append_tab();

--- a/src/termit.c
+++ b/src/termit.c
@@ -72,7 +72,11 @@ static void pack_widgets()
 {
     GtkWidget *vbox = gtk_vbox_new(FALSE, 0);
     termit.hbox = gtk_hbox_new(FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(termit.hbox), termit.menu_bar, FALSE, 0, 0);
+    if( !configs.top_menu )
+        gtk_box_pack_start(GTK_BOX(termit.hbox), termit.menu_bar, FALSE, 0, 0);
+    else
+        gtk_box_pack_start(GTK_BOX(vbox), termit.menu_bar, FALSE, 0, 0);
+
     gtk_box_pack_start(GTK_BOX(termit.hbox), termit.b_toggle_search, FALSE, 0, 0);
     gtk_box_pack_start(GTK_BOX(termit.hbox), termit.search_entry, FALSE, 0, 0);
     gtk_box_pack_start(GTK_BOX(termit.hbox), termit.b_find_prev, FALSE, 0, 0);

--- a/src/termit.h
+++ b/src/termit.h
@@ -39,6 +39,7 @@ struct TermitData
     GtkWidget *menu;
     GtkWidget *mi_show_scrollbar;
     GtkWidget *hbox;
+    GtkWidget *vbox;
     GtkWidget *menu_bar;
     gint tab_max_number;
 };

--- a/src/termit_core_api.c
+++ b/src/termit_core_api.c
@@ -188,7 +188,7 @@ void termit_after_show_all()
 void termit_reconfigure()
 {
     gtk_widget_destroy(termit.menu);
-    gtk_container_remove(GTK_CONTAINER(termit.hbox), termit.menu_bar);
+    gtk_container_remove((configs.top_menu)?GTK_CONTAINER(termit.vbox):GTK_CONTAINER(termit.hbox), termit.menu_bar);
 
     termit_config_deinit();
     termit_configs_set_defaults();
@@ -197,8 +197,8 @@ void termit_reconfigure()
 
     termit_create_popup_menu();
     termit_create_menubar();
-    gtk_box_pack_start(GTK_BOX(termit.hbox), termit.menu_bar, FALSE, 0, 0);
-    gtk_box_reorder_child(GTK_BOX(termit.hbox), termit.menu_bar, 0);
+    gtk_box_pack_start((configs.top_menu)?GTK_CONTAINER(termit.vbox):GTK_CONTAINER(termit.hbox), termit.menu_bar, FALSE, 0, 0);
+    gtk_box_reorder_child((configs.top_menu)?GTK_CONTAINER(termit.vbox):GTK_CONTAINER(termit.hbox), termit.menu_bar, 0);
     gtk_widget_show_all(termit.main_window);
     termit_after_show_all();
 }


### PR DESCRIPTION
Here's a topMenu option that I've been using. This simply places the menu at the top rather than the bottom.
Enable by adding

``` lua
defailts.topMenu = true
```

to your rc file.
