### PR TITLE
Fixed font size string issue.

### DIFF
--- a/doc/rc.lua.example
+++ b/doc/rc.lua.example
@@ -100,7 +100,7 @@ table.insert(userMenu, mi)
 
 function changeTabFontSize(delta)
     tab = tabs[currentTabIndex()]
-    setTabFont(string.sub(tab.font, 1, string.find(tab.font, '%d+$') - 1)..(tab.fontSize + delta))
+    setTabFont(string.sub(tab.font, 1, string.find(tab.font, '[%d.]+$') - 1)..(tostring(tab.fontSize + delta):gsub(',', '.')))
 end
 
 table.insert(userMenu, {name='Increase font size', action=function () changeTabFontSize(1) end})


### PR DESCRIPTION
This commit fixes #104 for me.

For some reason (locale?), the font size is returned as a string with a comma as a delimiter between the integer and the fraction part, as in "15,0" instead of "15.0".  This, in turn, requires a gsub call to replace the comma with a period so that the number is properly parsed again when feeding it to setTabFont().

This code should be safe to use even if the number is represented with a period already.

Also, using "%d" as a font size match is insufficient, as the font size might include a period.  Changing this to "[%d.]" does the trick.