### PR TITLE
Add icon to all windows of termit so xfce shows it.

### DIFF
--- a/src/termit.c
+++ b/src/termit.c
@@ -263,6 +263,7 @@ static void termit_init(const gchar* initFile, gchar** argv)
     termit.tab_max_number = 1;
 
     termit.main_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_default_icon_name("utilities-terminal");
     termit.statusbar = create_statusbar();
     create_search(&termit);
     termit.notebook = gtk_notebook_new();


### PR DESCRIPTION
This line adds the .desktop icon set to the application so it shows a symbol in the xfce4 taskbar.

Before, the xfce taskbar only showed a blank icon. It should not affect GNOME or KDE users.