### PR TITLE
Locale confusions removed

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -1,10 +1,12 @@
 SET(PO_FILES
+  da.po
   de.po
   es.po
   fr.po
   hu.po
   ja.po
   ko.po
+  nl.po
   pl.po
   ru.po
   sv.po

--- a/po/de.po
+++ b/po/de.po
@@ -38,7 +38,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -59,7 +59,7 @@ msgstr "Vordergrund"
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -119,7 +119,7 @@ msgstr "Konnte Verzeichnis '%s' nicht erstellen: %s"
 
 #: src/termit_preferences.c:212
 #, fuzzy
-msgid "audible bell"
+msgid "Audible bell"
 msgstr "Glocke"
 
 #~ msgid "Background image"

--- a/po/de.po
+++ b/po/de.po
@@ -16,29 +16,34 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+#, fuzzy
+msgid "Audible bell"
+msgstr "Glocke"
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr "Hintergrund"
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "Konnte keinen neuen Tab erzeugen"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
 msgstr ""
 "Konnte Befehl nicht untersuchen. Erstelle einen Tab mit der Kommandozeile"
 
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
-msgstr ""
-
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -49,11 +54,11 @@ msgstr "Bearbeiten"
 msgid "File"
 msgstr "Datei"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr "Schriftart"
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr "Vordergrund"
 
@@ -63,7 +68,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "Sitzung öffnen"
 
@@ -71,7 +76,7 @@ msgstr "Sitzung öffnen"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -79,7 +84,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "Sitzung speichern"
 
@@ -104,11 +109,11 @@ msgstr ""
 "Mehrere Tabs sind geöffnet.\n"
 "Trotzdem schließen?"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "Tab-Name"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 msgid "Title"
 msgstr "Titel"
 
@@ -116,11 +121,6 @@ msgstr "Titel"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "Konnte Verzeichnis '%s' nicht erstellen: %s"
-
-#: src/termit_preferences.c:212
-#, fuzzy
-msgid "Audible bell"
-msgstr "Glocke"
 
 #~ msgid "Background image"
 #~ msgstr "Hintergrundbild"

--- a/po/es.po
+++ b/po/es.po
@@ -15,28 +15,33 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+#, fuzzy
+msgid "Audible bell"
+msgstr "Timbre audible"
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr "Fondo"
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "No se puede crear una nueva pestaña"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
 msgstr "El comando no se entiende. Creando una nueva pestaña con shell"
 
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
-msgstr ""
-
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -47,11 +52,11 @@ msgstr "Editar"
 msgid "File"
 msgstr "Archivo"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr "Tipografía"
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr "Frente"
 
@@ -61,7 +66,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "Abrir sesión"
 
@@ -69,7 +74,7 @@ msgstr "Abrir sesión"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -77,7 +82,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "Guardar sesión"
 
@@ -102,11 +107,11 @@ msgstr ""
 "Hay varias pestañas abiertas.\n"
 "¿Cerrarlas todas?"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "Nombre de la pestaña"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 msgid "Title"
 msgstr "Título"
 
@@ -114,11 +119,6 @@ msgstr "Título"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "No se puede crear el directorio '%s': %s."
-
-#: src/termit_preferences.c:212
-#, fuzzy
-msgid "Audible bell"
-msgstr "Timbre audible"
 
 #~ msgid "Background image"
 #~ msgstr "Imagen de fondo"

--- a/po/es.po
+++ b/po/es.po
@@ -36,7 +36,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -57,7 +57,7 @@ msgstr "Frente"
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -117,7 +117,7 @@ msgstr "No se puede crear el directorio '%s': %s."
 
 #: src/termit_preferences.c:212
 #, fuzzy
-msgid "audible bell"
+msgid "Audible bell"
 msgstr "Timbre audible"
 
 #~ msgid "Background image"

--- a/po/fr.po
+++ b/po/fr.po
@@ -33,7 +33,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -54,7 +54,7 @@ msgstr ""
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -114,7 +114,7 @@ msgid "Unable to create directory '%s': %s"
 msgstr "Impossible de créer le dossier '%s': %s"
 
 #: src/termit_preferences.c:212
-msgid "audible bell"
+msgid "Audible bell"
 msgstr ""
 
 #~ msgid "Bookmarks"

--- a/po/fr.po
+++ b/po/fr.po
@@ -12,28 +12,32 @@ msgstr ""
 "X-Poedit-Language: French\n"
 "X-Poedit-Country: FRANCE\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+msgid "Audible bell"
+msgstr ""
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr ""
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "Impossible de créer un nouvel onglet"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
-msgstr ""
-
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -44,11 +48,11 @@ msgstr "Éditer"
 msgid "File"
 msgstr "Fichier"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr ""
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr ""
 
@@ -58,7 +62,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "Ouvrir une session"
 
@@ -66,7 +70,7 @@ msgstr "Ouvrir une session"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -74,7 +78,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "Enregistrer la session"
 
@@ -99,11 +103,11 @@ msgstr ""
 "Vous êtes sur le point de fermer plusieurs onglets.\n"
 "Voulez-vous vraiment continuer ?"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "Nom de l'onglet"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 #, fuzzy
 msgid "Title"
 msgstr "Fichier"
@@ -112,10 +116,6 @@ msgstr "Fichier"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "Impossible de créer le dossier '%s': %s"
-
-#: src/termit_preferences.c:212
-msgid "Audible bell"
-msgstr ""
 
 #~ msgid "Bookmarks"
 #~ msgstr "Marques-page"

--- a/po/hu.po
+++ b/po/hu.po
@@ -38,7 +38,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -59,7 +59,7 @@ msgstr "Előtér"
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -119,7 +119,7 @@ msgstr "A könyvtár létrehozása sikertelen '%s': %s"
 
 #: src/termit_preferences.c:212
 #, fuzzy
-msgid "audible bell"
+msgid "Audible bell"
 msgstr "Hallható figyelmeztetés"
 
 #~ msgid "Background image"

--- a/po/hu.po
+++ b/po/hu.po
@@ -16,29 +16,34 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+#, fuzzy
+msgid "Audible bell"
+msgstr "Hallható figyelmeztetés"
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr "Háttér"
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "Nem sikerült új fület létrehozni"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
 msgstr ""
 "Nem lehetséges a parancs értelmezése. Fül létrehozása shell segítségével"
 
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
-msgstr ""
-
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -49,11 +54,11 @@ msgstr "Szerkesztés"
 msgid "File"
 msgstr "Fájl"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr "Betűtípus"
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr "Előtér"
 
@@ -63,7 +68,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "Megnyitás"
 
@@ -71,7 +76,7 @@ msgstr "Megnyitás"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -79,7 +84,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "Mentés"
 
@@ -104,11 +109,11 @@ msgstr ""
 "Több fül is nyitva van.\n"
 "Bezárja mind?"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "Fül neve"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 msgid "Title"
 msgstr "Cím"
 
@@ -116,11 +121,6 @@ msgstr "Cím"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "A könyvtár létrehozása sikertelen '%s': %s"
-
-#: src/termit_preferences.c:212
-#, fuzzy
-msgid "Audible bell"
-msgstr "Hallható figyelmeztetés"
 
 #~ msgid "Background image"
 #~ msgstr "Háttérkép"

--- a/po/ja.po
+++ b/po/ja.po
@@ -34,7 +34,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -55,7 +55,7 @@ msgstr "前景"
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -113,7 +113,7 @@ msgstr "ディレクトリ '%s' が生成できません: %s"
 
 #: src/termit_preferences.c:212
 #, fuzzy
-msgid "audible bell"
+msgid "Audible bell"
 msgstr "可聴ベル"
 
 #~ msgid "Background image"

--- a/po/ja.po
+++ b/po/ja.po
@@ -13,28 +13,33 @@ msgstr ""
 "X-Poedit-Language: Japanese\n"
 "X-Poedit-Country: JAPAN\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+#, fuzzy
+msgid "Audible bell"
+msgstr "可聴ベル"
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr "背景"
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "新しいタブを作成できません"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
 msgstr "コマンドを解析できません。シェル経由でタブを作成します"
 
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
-msgstr ""
-
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -45,11 +50,11 @@ msgstr "編集"
 msgid "File"
 msgstr "ファイル"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr "フォント"
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr "前景"
 
@@ -59,7 +64,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "セッションを開く"
 
@@ -67,7 +72,7 @@ msgstr "セッションを開く"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -75,7 +80,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "セッションを保存する"
 
@@ -98,11 +103,11 @@ msgid ""
 "Close anyway?"
 msgstr "終了しますか?"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "タブ名"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 msgid "Title"
 msgstr "タイトル"
 
@@ -110,11 +115,6 @@ msgstr "タイトル"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "ディレクトリ '%s' が生成できません: %s"
-
-#: src/termit_preferences.c:212
-#, fuzzy
-msgid "Audible bell"
-msgstr "可聴ベル"
 
 #~ msgid "Background image"
 #~ msgstr "背景画像"

--- a/po/ko.po
+++ b/po/ko.po
@@ -12,28 +12,32 @@ msgstr ""
 "X-Poedit-Language: Korean\n"
 "X-Poedit-Country: KOREA, REPUBLIC OF\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+msgid "Audible bell"
+msgstr ""
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr ""
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "새 탭을 만들 수 없습니다"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
 msgstr "명령을 해석할 수 없습니다. 쉘을 이용한 새 탭을 만듭니다"
 
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
-msgstr ""
-
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -44,11 +48,11 @@ msgstr "편집"
 msgid "File"
 msgstr "파일"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr ""
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr ""
 
@@ -58,7 +62,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "세션 열기"
 
@@ -66,7 +70,7 @@ msgstr "세션 열기"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -74,7 +78,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "세션 저장"
 
@@ -99,11 +103,11 @@ msgstr ""
 "다른 탭들이 아직 열려 있습니다.\n"
 "전부 닫고 종료할까요 ?"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "탭 이름"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 #, fuzzy
 msgid "Title"
 msgstr "파일"
@@ -112,10 +116,6 @@ msgstr "파일"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "디렉토리를 만들 수 없습니다 '%s': %s"
-
-#: src/termit_preferences.c:212
-msgid "Audible bell"
-msgstr ""
 
 #~ msgid "Bookmarks"
 #~ msgstr "책갈피"

--- a/po/ko.po
+++ b/po/ko.po
@@ -33,7 +33,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -54,7 +54,7 @@ msgstr ""
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -114,7 +114,7 @@ msgid "Unable to create directory '%s': %s"
 msgstr "디렉토리를 만들 수 없습니다 '%s': %s"
 
 #: src/termit_preferences.c:212
-msgid "audible bell"
+msgid "Audible bell"
 msgstr ""
 
 #~ msgid "Bookmarks"

--- a/po/nl.po
+++ b/po/nl.po
@@ -33,7 +33,7 @@ msgid "Copy"
 msgstr "Kopiëren"
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr "Verwijderen"
 
 #: src/termit.c:190
@@ -54,7 +54,7 @@ msgstr "Voorgrond"
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr "Openen"
 
 #. Sessions menu
@@ -113,5 +113,5 @@ msgid "Unable to create directory '%s': %s"
 msgstr "De map ‘%s’ kan niet worden aangemaakt: %s"
 
 #: src/termit_preferences.c:212
-msgid "audible bell"
+msgid "Audible bell"
 msgstr "Luide bel"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,29 +12,34 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr "Toepassen op alle tabbladen"
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+msgid "Audible bell"
+msgstr "Luide bel"
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr "Achtergrond"
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "Er kan geen nieuw tabblad worden geopend"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
-msgstr "De opdracht kan niet worden verwerkt. Bezig met openen van tabblad met shell…"
-
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
-msgstr "Kopiëren"
+msgstr ""
+"De opdracht kan niet worden verwerkt. Bezig met openen van tabblad met shell…"
 
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
 msgstr "Verwijderen"
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
+msgstr "Kopiëren"
 
 #: src/termit.c:190
 msgid "Edit"
@@ -44,11 +49,11 @@ msgstr "Bewerken"
 msgid "File"
 msgstr "Bestand"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr "Lettertype"
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr "Voorgrond"
 
@@ -58,7 +63,7 @@ msgid "New tab"
 msgstr "Openen"
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "Sessie openen"
 
@@ -66,7 +71,7 @@ msgstr "Sessie openen"
 msgid "Paste"
 msgstr "Plakken"
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr "Instellingen"
 
@@ -74,7 +79,7 @@ msgstr "Instellingen"
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "Sessie opslaan"
 
@@ -99,11 +104,11 @@ msgstr ""
 "Er zijn nog openstaande tabbladen.\n"
 "Weet u zeker dat u wilt doorgaan?"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "Tabbladnaam"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 msgid "Title"
 msgstr "Naam"
 
@@ -111,7 +116,3 @@ msgstr "Naam"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "De map ‘%s’ kan niet worden aangemaakt: %s"
-
-#: src/termit_preferences.c:212
-msgid "Audible bell"
-msgstr "Luide bel"

--- a/po/pl.po
+++ b/po/pl.po
@@ -38,7 +38,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -59,7 +59,7 @@ msgstr "Pierwszy plan"
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -119,7 +119,7 @@ msgstr "Nie można utworzyć katalogu '%s': %s"
 
 #: src/termit_preferences.c:212
 #, fuzzy
-msgid "audible bell"
+msgid "Audible bell"
 msgstr "Głośny dzwonek"
 
 #~ msgid "Background image"

--- a/po/pl.po
+++ b/po/pl.po
@@ -17,28 +17,33 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+#, fuzzy
+msgid "Audible bell"
+msgstr "Głośny dzwonek"
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr "Tło"
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "Nie można utworzyć nowej karty"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
 msgstr "Nie można przetworzyć polecenia. Tworzenia karty z powłoki"
 
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
-msgstr ""
-
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -49,11 +54,11 @@ msgstr "Edycja"
 msgid "File"
 msgstr "Plik"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr "Czcionka"
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr "Pierwszy plan"
 
@@ -63,7 +68,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "Otwórz sesje"
 
@@ -71,7 +76,7 @@ msgstr "Otwórz sesje"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -79,7 +84,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "Zapisz sesje "
 
@@ -104,11 +109,11 @@ msgstr ""
 "Kilka kart jest otwartych.\n"
 "Zamknąć pomimo to?"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "Nazwa Karty"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 msgid "Title"
 msgstr "Tytuł"
 
@@ -116,11 +121,6 @@ msgstr "Tytuł"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "Nie można utworzyć katalogu '%s': %s"
-
-#: src/termit_preferences.c:212
-#, fuzzy
-msgid "Audible bell"
-msgstr "Głośny dzwonek"
 
 #~ msgid "Background image"
 #~ msgstr "Obraz tła"

--- a/po/ru.po
+++ b/po/ru.po
@@ -37,7 +37,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -58,7 +58,7 @@ msgstr ""
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -118,7 +118,7 @@ msgid "Unable to create directory '%s': %s"
 msgstr "Невозможно создать директорию '%s': %s"
 
 #: src/termit_preferences.c:212
-msgid "audible bell"
+msgid "Audible bell"
 msgstr ""
 
 #~ msgid "Bookmarks"

--- a/po/ru.po
+++ b/po/ru.po
@@ -16,28 +16,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+msgid "Audible bell"
+msgstr ""
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr ""
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "Ошибка открытия новой вкладки"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
-msgstr ""
-
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -48,11 +52,11 @@ msgstr "Правка"
 msgid "File"
 msgstr "Файл"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr ""
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr ""
 
@@ -62,7 +66,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "Открыть сессию"
 
@@ -70,7 +74,7 @@ msgstr "Открыть сессию"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -78,7 +82,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "Сохранить сессию"
 
@@ -103,11 +107,11 @@ msgstr ""
 "Открыто несколько вкладок.\n"
 "Закрыть?"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "Заголовок вкладки"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 #, fuzzy
 msgid "Title"
 msgstr "Файл"
@@ -116,10 +120,6 @@ msgstr "Файл"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "Невозможно создать директорию '%s': %s"
-
-#: src/termit_preferences.c:212
-msgid "Audible bell"
-msgstr ""
 
 #~ msgid "Bookmarks"
 #~ msgstr "Закладки"

--- a/po/sv.po
+++ b/po/sv.po
@@ -19,7 +19,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -40,7 +40,7 @@ msgstr "Frgrund"
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -98,7 +98,7 @@ msgstr "Kan inte skapa mappen '%s': %s"
 
 #: src/termit_preferences.c:212
 #, fuzzy
-msgid "audible bell"
+msgid "Audible bell"
 msgstr "Ljudsignal"
 
 #~ msgid "Background image"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,25 +1,30 @@
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+#, fuzzy
+msgid "Audible bell"
+msgstr "Ljudsignal"
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr "Bakgrund"
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "Kan inte skapa ny flik"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
 msgstr "Kan inte tolka kommando. Skapar interaktiv flik."
 
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
-msgstr ""
-
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -30,11 +35,11 @@ msgstr "Redigera"
 msgid "File"
 msgstr "Arkiv"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr "Teckensnitt"
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr "Frgrund"
 
@@ -44,7 +49,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "ppna arbetspass"
 
@@ -52,7 +57,7 @@ msgstr "ppna arbetspass"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -60,7 +65,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "Spara arbetspass"
 
@@ -83,11 +88,11 @@ msgid ""
 "Close anyway?"
 msgstr ""
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "Fliknamn"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 msgid "Title"
 msgstr "Rubrik"
 
@@ -95,11 +100,6 @@ msgstr "Rubrik"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "Kan inte skapa mappen '%s': %s"
-
-#: src/termit_preferences.c:212
-#, fuzzy
-msgid "Audible bell"
-msgstr "Ljudsignal"
 
 #~ msgid "Background image"
 #~ msgstr "Bakgrundsbild"

--- a/po/termit.pot
+++ b/po/termit.pot
@@ -19,7 +19,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -40,7 +40,7 @@ msgstr ""
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu

--- a/po/termit.pot
+++ b/po/termit.pot
@@ -97,5 +97,5 @@ msgid "Unable to create directory '%s': %s"
 msgstr ""
 
 #: src/termit_preferences.c:212
-msgid "audible bell"
+msgid "Audible bell"
 msgstr ""

--- a/po/termit.pot
+++ b/po/termit.pot
@@ -1,25 +1,29 @@
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+msgid "Audible bell"
+msgstr ""
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr ""
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr ""
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
-msgstr ""
-
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -30,11 +34,11 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr ""
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr ""
 
@@ -44,7 +48,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr ""
 
@@ -52,7 +56,7 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -60,7 +64,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr ""
 
@@ -83,19 +87,15 @@ msgid ""
 "Close anyway?"
 msgstr ""
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr ""
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 msgid "Title"
 msgstr ""
 
 #: src/sessions.c:90
 #, c-format
 msgid "Unable to create directory '%s': %s"
-msgstr ""
-
-#: src/termit_preferences.c:212
-msgid "Audible bell"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -13,28 +13,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/termit_preferences.c:218
+#: src/termit_preferences.c:219
 msgid "Apply to all tabs"
 msgstr ""
 
-#: src/termit_preferences.c:206
+#: src/termit_preferences.c:213
+msgid "Audible bell"
+msgstr ""
+
+#: src/termit_preferences.c:207
 msgid "Background"
 msgstr ""
 
-#: src/termit_core_api.c:440
+#: src/termit_core_api.c:464
 msgid "Cannot create a new tab"
 msgstr "無法建立新分頁"
 
-#: src/termit_core_api.c:392
+#: src/termit_core_api.c:416
 msgid "Cannot parse command. Creating tab with shell"
-msgstr ""
-
-#: src/termit.c:187 src/termit.c:226
-msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
 msgid "Close tab"
+msgstr ""
+
+#: src/termit.c:187 src/termit.c:226
+msgid "Copy"
 msgstr ""
 
 #: src/termit.c:190
@@ -45,11 +49,11 @@ msgstr "編輯"
 msgid "File"
 msgstr "檔案"
 
-#: src/termit_preferences.c:192
+#: src/termit_preferences.c:193
 msgid "Font"
 msgstr ""
 
-#: src/termit_preferences.c:199
+#: src/termit_preferences.c:200
 msgid "Foreground"
 msgstr ""
 
@@ -59,7 +63,7 @@ msgid "New tab"
 msgstr ""
 
 #. Sessions menu
-#: src/termit.c:202 src/callbacks.c:395
+#: src/termit.c:202 src/callbacks.c:418
 msgid "Open session"
 msgstr "開啟作業階段"
 
@@ -67,7 +71,7 @@ msgstr "開啟作業階段"
 msgid "Paste"
 msgstr ""
 
-#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:166
+#: src/termit.c:186 src/termit.c:225 src/termit_preferences.c:167
 msgid "Preferences"
 msgstr ""
 
@@ -75,7 +79,7 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: src/termit.c:203 src/callbacks.c:365
+#: src/termit.c:203 src/callbacks.c:388
 msgid "Save session"
 msgstr "儲存作業階段"
 
@@ -98,11 +102,11 @@ msgid ""
 "Close anyway?"
 msgstr "已開啟數個分頁。是否關閉？"
 
-#: src/callbacks.c:274 src/callbacks.c:285
+#: src/callbacks.c:297 src/callbacks.c:308
 msgid "Tab name"
 msgstr "分頁名稱"
 
-#: src/termit_preferences.c:186
+#: src/termit_preferences.c:187
 #, fuzzy
 msgid "Title"
 msgstr "檔案"
@@ -111,10 +115,6 @@ msgstr "檔案"
 #, c-format
 msgid "Unable to create directory '%s': %s"
 msgstr "無法建立目錄 '%s': %s"
-
-#: src/termit_preferences.c:212
-msgid "Audible bell"
-msgstr ""
 
 #~ msgid "Bookmarks"
 #~ msgstr "書籤"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -34,7 +34,7 @@ msgid "Copy"
 msgstr ""
 
 #: src/termit.c:170 src/termit.c:223
-msgid "Delete"
+msgid "Close tab"
 msgstr ""
 
 #: src/termit.c:190
@@ -55,7 +55,7 @@ msgstr ""
 
 #. File menu
 #: src/termit.c:169 src/termit.c:222
-msgid "Open"
+msgid "New tab"
 msgstr ""
 
 #. Sessions menu
@@ -113,7 +113,7 @@ msgid "Unable to create directory '%s': %s"
 msgstr "無法建立目錄 '%s': %s"
 
 #: src/termit_preferences.c:212
-msgid "audible bell"
+msgid "Audible bell"
 msgstr ""
 
 #~ msgid "Bookmarks"

--- a/src/termit.c
+++ b/src/termit.c
@@ -166,8 +166,8 @@ void termit_create_menubar()
     GtkWidget* menu_bar = gtk_menu_bar_new();
 
     // File menu
-    GtkWidget *mi_new_tab = termit_lua_menu_item_from_string(_("Open"), "openTab");
-    GtkWidget *mi_close_tab = termit_lua_menu_item_from_string(_("Delete"), "closeTab");
+    GtkWidget *mi_new_tab = termit_lua_menu_item_from_string(_("New tab"), "openTab");
+    GtkWidget *mi_close_tab = termit_lua_menu_item_from_string(_("Close tab"), "closeTab");
     GtkWidget *mi_exit = termit_lua_menu_item_from_string(_("Quit"), "quit");
 
     GtkWidget *mi_file = gtk_menu_item_new_with_label(_("File"));
@@ -219,8 +219,8 @@ void termit_create_popup_menu()
 {
     termit.menu = gtk_menu_new();
 
-    GtkWidget *mi_new_tab = termit_lua_menu_item_from_string(_("Open"), "openTab");
-    GtkWidget *mi_close_tab = termit_lua_menu_item_from_string(_("Delete"), "closeTab");
+    GtkWidget *mi_new_tab = termit_lua_menu_item_from_string(_("New tab"), "openTab");
+    GtkWidget *mi_close_tab = termit_lua_menu_item_from_string(_("Close tab"), "closeTab");
     GtkWidget *mi_set_tab_name = termit_lua_menu_item_from_string(_("Set tab name..."), "setTabTitleDlg");
     GtkWidget *mi_edit_preferences = termit_lua_menu_item_from_string(_("Preferences"), "preferencesDlg");
     GtkWidget *mi_copy = termit_lua_menu_item_from_string(_("Copy"), "copy");

--- a/src/termit_preferences.c
+++ b/src/termit_preferences.c
@@ -210,7 +210,7 @@ void termit_preferences_dialog(struct TermitTab *pTab)
     GtkWidget* btn_audible_bell = gtk_check_button_new();
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(btn_audible_bell), pTab->audible_bell);
     g_signal_connect(btn_audible_bell, "toggled", G_CALLBACK(dlg_set_audible_bell), pTab);
-    TERMIT_PREFERENCE_ROW(_("audible bell"), btn_audible_bell);
+    TERMIT_PREFERENCE_ROW(_("Audible bell"), btn_audible_bell);
 
     // apply to al tabs
     GtkWidget* btn_apply_to_all_tabs = gtk_check_button_new();


### PR DESCRIPTION
Changed "Delete" to "Close tab" and "Open" to "New tab" as these terms were confusing.
Also capitalized "Audible bell"

Then the *.po and *.pot files were updated except for danish. There seems to be a problem there where some chars are dropped.